### PR TITLE
Bug fix for when a SpecFlow scenario starts with a numeric digit.

### DIFF
--- a/ADOTestConnector64/FirstCommand.cs
+++ b/ADOTestConnector64/FirstCommand.cs
@@ -514,7 +514,14 @@ namespace ADOTestConnector64
         {
             fullLine = fullLine.Replace("Scenario:", "");
             fullLine = fullLine.Replace("Scenario Outline:", "");
-            return fullLine.Trim();
+            fullLine = fullLine.Trim();
+
+            // The following 2 lines are to match SpecFlows handling of methods that start with a digit.
+            // If a Scenario starts with a number, SpecFlow automatically adds an underscore otherwise the method will not compile.
+            char firstCharacter = fullLine.ToCharArray()[0];
+            if (Char.IsDigit(firstCharacter)) fullLine = $"_{fullLine}";
+
+            return fullLine;
         }
 
         private string UpdateTestReference(string fullLine, TagPattern tagPattern, int testReferenceId)

--- a/ADOTestConnector64/source.extension.vsixmanifest
+++ b/ADOTestConnector64/source.extension.vsixmanifest
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="ADOTestConnector64.83e890f7-8c2e-413a-8483-92144c3c2423" Version="1.0" Language="en-US" Publisher="Paul Le May" />
-    <DisplayName>ADOTestConnector64</DisplayName>
-    <Description>Empty VSIX Project.</Description>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="ADOTestConnector64.83e890f7-8c2e-413a-8483-92144c3c2423" Version="1.1" Language="en-US" Publisher="Paul Le May" />
+        <DisplayName>ADOTestConnector64</DisplayName>
+        <Description xml:space="preserve">Empty VSIX Project.</Description>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
Added a small fix for the following scenario...
If a SpecFlow Scenario starts with a numeric character, Specflow automatically adds an underscore (_) to the method name so that the method is valid and can be compiled (methods cannot start with numeric characters).

In this case, the ADO Test Connector was not correctly setting the 'Automated test name' field within the Test Case(s) as the underscore was missing.